### PR TITLE
6 level of folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /coverage.txt
 /dist
 /vendor
+/disk_usage_exporter

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME := disk_usage_exporter
 PACKAGE := github.com/dundee/$(NAME)
-VERSION := $(shell git describe --tags 2>/dev/null)
+VERSION := $(shell git tag -l | grep -E "^v[0-9]+\.[0-9]+\.[0-9]+$$" | sort -V | tail -1 2>/dev/null)-$(shell git rev-parse --short HEAD 2>/dev/null)
 GIT_SHA := $(shell git rev-parse HEAD 2>/dev/null)
 GOFLAGS ?= -buildmode=pie -trimpath -mod=readonly -modcacherw
 LDFLAGS := -s -w -extldflags '-static' \

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -76,6 +76,9 @@ and reporting which directories consume what space.`,
 		if viper.GetString("storage-path") != "" && viper.GetInt("scan-interval-minutes") > 0 {
 			e.SetStorageConfig(viper.GetString("storage-path"), viper.GetInt("scan-interval-minutes"))
 		}
+		
+		// Configure max processors
+		e.SetMaxProcs(viper.GetInt("max-procs"))
 
 		if viper.GetString("mode") == "file" {
 			e.WriteToTextfile(viper.GetString("output-file"))
@@ -115,6 +118,7 @@ func init() {
 	flags.StringP("storage-path", "s", "", "Path to store cached analysis data")
 	flags.IntP("scan-interval-minutes", "t", 0, "Scan interval in minutes for background caching (0 = disabled)")
 	flags.String("log-level", "info", "Log level (trace, debug, info, warn, error, fatal, panic)")
+	flags.IntP("max-procs", "j", 4, "Maximum number of CPU cores to use for parallel processing")
 
 	viper.BindPFlags(flags)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -43,6 +43,11 @@ and reporting which directories consume what space.`,
 			e.SetBasicAuth(viper.GetStringMapString("basic-auth-users"))
 		}
 
+		// Configure storage and scan interval if specified
+		if viper.GetString("storage-path") != "" && viper.GetInt("scan-interval-minutes") > 0 {
+			e.SetStorageConfig(viper.GetString("storage-path"), viper.GetInt("scan-interval-minutes"))
+		}
+
 		if viper.GetString("mode") == "file" {
 			e.WriteToTextfile(viper.GetString("output-file"))
 			log.Info("Done - exiting.")
@@ -76,6 +81,8 @@ func init() {
 	)
 	flags.StringToString("multi-paths", map[string]string{}, "Multiple paths where to analyze disk usage, in format /path1=level1,/path2=level2,...")
 	flags.StringToString("basic-auth-users", map[string]string{}, "Basic Auth users and their passwords as bcypt hashes")
+	flags.StringP("storage-path", "s", "", "Path to store cached analysis data")
+	flags.IntP("scan-interval-minutes", "t", 0, "Scan interval in minutes for background caching (0 = disabled)")
 
 	viper.BindPFlags(flags)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,6 +48,12 @@ and reporting which directories consume what space.`,
 			log.Warnf("Invalid log level '%s', using default 'info'", logLevel)
 			log.SetLevel(log.InfoLevel)
 		}
+		
+		// Set log formatter to include timestamps
+		log.SetFormatter(&log.TextFormatter{
+			TimestampFormat: "2006-01-02 15:04:05",
+			FullTimestamp:   true,
+		})
 
 		printHeader()
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,6 +40,15 @@ and reporting which directories consume what space.`,
 			return
 		}
 		
+		// Set log level from configuration
+		logLevel := viper.GetString("log-level")
+		if level, err := log.ParseLevel(logLevel); err == nil {
+			log.SetLevel(level)
+		} else {
+			log.Warnf("Invalid log level '%s', using default 'info'", logLevel)
+			log.SetLevel(log.InfoLevel)
+		}
+
 		printHeader()
 
 		paths := transformMultipaths(viper.GetStringMapString("multi-paths"))
@@ -99,6 +108,7 @@ func init() {
 	flags.StringToString("basic-auth-users", map[string]string{}, "Basic Auth users and their passwords as bcypt hashes")
 	flags.StringP("storage-path", "s", "", "Path to store cached analysis data")
 	flags.IntP("scan-interval-minutes", "t", 0, "Scan interval in minutes for background caching (0 = disabled)")
+	flags.String("log-level", "info", "Log level (trace, debug, info, warn, error, fatal, panic)")
 
 	viper.BindPFlags(flags)
 }

--- a/config-basic.yml
+++ b/config-basic.yml
@@ -1,0 +1,17 @@
+# Basic Disk Usage Prometheus Exporter Configuration
+# This configuration runs without background caching (live analysis mode)
+
+# Basic configuration
+analyzed-path: "/tmp"
+bind-address: "0.0.0.0:9995"
+dir-level: 1
+mode: "http"
+follow-symlinks: false
+
+# Directories to ignore during analysis
+ignore-dirs:
+  - /proc
+  - /dev
+  - /sys
+  - /run
+  - /var/cache/rsnapshot

--- a/config-basic.yml
+++ b/config-basic.yml
@@ -3,10 +3,14 @@
 
 # Basic configuration
 analyzed-path: "/tmp"
-bind-address: "0.0.0.0:9995"
+bind-address: "0.0.0.0:9996"
 dir-level: 1
 mode: "http"
 follow-symlinks: false
+
+# Log level configuration
+# Available levels: trace, debug, info, warn, error, fatal, panic
+log-level: "debug"
 
 # Directories to ignore during analysis
 ignore-dirs:

--- a/config-basic.yml
+++ b/config-basic.yml
@@ -12,6 +12,10 @@ follow-symlinks: false
 # Available levels: trace, debug, info, warn, error, fatal, panic
 log-level: "debug"
 
+# CPU cores configuration
+# Maximum number of CPU cores to use for parallel processing
+max-procs: 4
+
 # Directories to ignore during analysis
 ignore-dirs:
   - /proc

--- a/config-caching.yml
+++ b/config-caching.yml
@@ -1,0 +1,23 @@
+# Disk Usage Prometheus Exporter Configuration with Background Caching
+# This configuration enables background caching for better performance
+
+# Basic configuration
+analyzed-path: "/home"
+bind-address: "0.0.0.0:9995"
+dir-level: 2
+mode: "http"
+follow-symlinks: false
+
+# Background caching configuration
+# Both storage-path and scan-interval-minutes must be set to enable caching
+storage-path: "/tmp/disk-usage-cache"
+scan-interval-minutes: 15
+
+# Directories to ignore during analysis
+ignore-dirs:
+  - /proc
+  - /dev
+  - /sys
+  - /run
+  - /var/cache/rsnapshot
+  - /tmp

--- a/config-caching.yml
+++ b/config-caching.yml
@@ -2,9 +2,10 @@
 # This configuration enables background caching for better performance
 
 # Basic configuration
-analyzed-path: "/mnt/meta-test"
+# analyzed-path: "/mnt/meta-test"
+analyzed-path: "/home"
 bind-address: "0.0.0.0:9996"
-dir-level: 2
+dir-level: 1
 mode: "http"
 follow-symlinks: false
 

--- a/config-caching.yml
+++ b/config-caching.yml
@@ -2,16 +2,20 @@
 # This configuration enables background caching for better performance
 
 # Basic configuration
-analyzed-path: "/home"
-bind-address: "0.0.0.0:9995"
+analyzed-path: "/mnt/meta-test"
+bind-address: "0.0.0.0:9996"
 dir-level: 2
 mode: "http"
 follow-symlinks: false
 
+# Log level configuration
+# Available levels: trace, debug, info, warn, error, fatal, panic
+log-level: "debug"
+
 # Background caching configuration
 # Both storage-path and scan-interval-minutes must be set to enable caching
 storage-path: "/tmp/disk-usage-cache"
-scan-interval-minutes: 15
+scan-interval-minutes: 1
 
 # Directories to ignore during analysis
 ignore-dirs:

--- a/config-caching.yml
+++ b/config-caching.yml
@@ -3,7 +3,7 @@
 
 # Basic configuration
 # analyzed-path: "/mnt/meta-test"
-analyzed-path: "/mnt/meta-test"
+analyzed-path: "/home"
 bind-address: "0.0.0.0:9996"
 dir-level: 1
 mode: "http"

--- a/config-caching.yml
+++ b/config-caching.yml
@@ -3,7 +3,7 @@
 
 # Basic configuration
 # analyzed-path: "/mnt/meta-test"
-analyzed-path: "/home"
+analyzed-path: "/mnt/meta-test"
 bind-address: "0.0.0.0:9996"
 dir-level: 1
 mode: "http"
@@ -12,6 +12,10 @@ follow-symlinks: false
 # Log level configuration
 # Available levels: trace, debug, info, warn, error, fatal, panic
 log-level: "debug"
+
+# CPU cores configuration
+# Maximum number of CPU cores to use for parallel processing
+max-procs: 12
 
 # Background caching configuration
 # Both storage-path and scan-interval-minutes must be set to enable caching

--- a/config-multipaths.yml
+++ b/config-multipaths.yml
@@ -10,6 +10,10 @@ follow-symlinks: false
 # Available levels: trace, debug, info, warn, error, fatal, panic
 log-level: "debug"
 
+# CPU cores configuration
+# Maximum number of CPU cores to use for parallel processing
+max-procs: 4
+
 # Multiple paths configuration
 # Each path can have different directory depth levels
 multi-paths:

--- a/config-multipaths.yml
+++ b/config-multipaths.yml
@@ -2,9 +2,13 @@
 # This configuration monitors multiple directories with different depth levels
 
 # Basic configuration
-bind-address: "0.0.0.0:9995"
+bind-address: "0.0.0.0:9996"
 mode: "http"
 follow-symlinks: false
+
+# Log level configuration
+# Available levels: trace, debug, info, warn, error, fatal, panic
+log-level: "debug"
 
 # Multiple paths configuration
 # Each path can have different directory depth levels

--- a/config-multipaths.yml
+++ b/config-multipaths.yml
@@ -1,0 +1,32 @@
+# Disk Usage Prometheus Exporter Configuration with Multiple Paths
+# This configuration monitors multiple directories with different depth levels
+
+# Basic configuration
+bind-address: "0.0.0.0:9995"
+mode: "http"
+follow-symlinks: false
+
+# Multiple paths configuration
+# Each path can have different directory depth levels
+multi-paths:
+  /home: 2
+  /var: 3
+  /tmp: 1
+  /opt: 2
+
+# Background caching configuration (optional)
+storage-path: "/tmp/disk-usage-cache"
+scan-interval-minutes: 20
+
+# Directories to ignore during analysis
+ignore-dirs:
+  - /proc
+  - /dev
+  - /sys
+  - /run
+  - /var/cache/rsnapshot
+
+# Basic authentication (optional)
+# Passwords must be bcrypt hashed
+# basic-auth-users:
+#   admin: $2b$12$hNf2lSsxfm0.i4a.1kVpSOVyBCfIB51VRjgBUyv6kdnyTlgWj81Ay

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,41 @@
+# Disk Usage Prometheus Exporter Configuration
+# This is an example configuration file for disk_usage_exporter
+
+# Basic configuration
+analyzed-path: "/mnt"
+bind-address: "0.0.0.0:9995"
+dir-level: 1
+mode: "http"
+follow-symlinks: false
+
+# Background caching configuration (optional)
+# Both storage-path and scan-interval-minutes must be set to enable caching
+storage-path: "/tmp/gdu-cache"
+scan-interval-minutes: 30
+
+# Directories to ignore during analysis
+ignore-dirs:
+  - /proc
+  - /dev
+  - /sys
+  - /run
+  - /var/cache/rsnapshot
+  - /tmp
+
+# Multiple paths configuration (alternative to analyzed-path)
+# Uncomment and configure as needed
+# multi-paths:
+#   /home: 2
+#   /var: 3
+#   /tmp: 1
+
+# Basic authentication (optional)
+# Passwords must be bcrypt hashed
+# basic-auth-users:
+#   admin: $2b$12$hNf2lSsxfm0.i4a.1kVpSOVyBCfIB51VRjgBUyv6kdnyTlgWj81Ay
+#   user: $2b$12$MzUQjmLxPRM9WW6OI4ZzwuZHB7ubHiiSnngJxIufgZms27nw.5ZAq
+
+# File output mode configuration (alternative to http mode)
+# Uncomment to enable file output mode
+# mode: "file"
+# output-file: "./disk-usage-exporter.prom"

--- a/config.yml
+++ b/config.yml
@@ -12,6 +12,10 @@ follow-symlinks: false
 # Available levels: trace, debug, info, warn, error, fatal, panic
 log-level: "debug"
 
+# CPU cores configuration
+# Maximum number of CPU cores to use for parallel processing
+max-procs: 4
+
 # Background caching configuration (optional)
 # Both storage-path and scan-interval-minutes must be set to enable caching
 storage-path: "/tmp/gdu-cache"

--- a/config.yml
+++ b/config.yml
@@ -3,10 +3,14 @@
 
 # Basic configuration
 analyzed-path: "/mnt"
-bind-address: "0.0.0.0:9995"
+bind-address: "0.0.0.0:9996"
 dir-level: 1
 mode: "http"
 follow-symlinks: false
+
+# Log level configuration
+# Available levels: trace, debug, info, warn, error, fatal, panic
+log-level: "debug"
 
 # Background caching configuration (optional)
 # Both storage-path and scan-interval-minutes must be set to enable caching

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -101,16 +101,23 @@ func (e *Exporter) performScan() {
 	analyzer.SetFollowSymlinks(e.followSymlinks)
 
 	for path := range e.paths {
+		// Track scan time for each path
+		startTime := time.Now()
+		log.Infof("Starting background scan for path: %s", path)
+		
 		// Use constGC=true for better memory management during intensive analysis
 		dir := analyzer.AnalyzeDir(path, e.shouldDirBeIgnored, true)
 		dir.UpdateStats(fs.HardLinkedItems{})
-		// Note: metrics will be read from storage during ServeHTTP
-
+		
+		// Log scan completion time
+		elapsedTime := time.Since(startTime)
+		log.Infof("Background scan completed for path: %s, elapsed time: %v", path, elapsedTime)
+		
 		// Reset progress for next analysis
 		analyzer.ResetProgress()
 	}
 
-	log.Info("Background scan completed")
+	log.Info("All background scans completed")
 }
 
 func (e *Exporter) runAnalysis() {
@@ -124,16 +131,24 @@ func (e *Exporter) runAnalysis() {
 	analyzer.SetFollowSymlinks(e.followSymlinks)
 
 	for path, level := range e.paths {
+		// Track scan time for each path
+		startTime := time.Now()
+		log.Infof("Starting live analysis for path: %s", path)
+		
 		// Use constGC=true for better memory management during intensive analysis
 		dir := analyzer.AnalyzeDir(path, e.shouldDirBeIgnored, true)
 		dir.UpdateStats(fs.HardLinkedItems{})
 		e.reportItem(dir, 0, level)
+		
+		// Log scan completion time
+		elapsedTime := time.Since(startTime)
+		log.Infof("Live analysis completed for path: %s, elapsed time: %v", path, elapsedTime)
 
 		// Reset progress for next analysis
 		analyzer.ResetProgress()
 	}
 
-	log.Info("Analysis done")
+	log.Info("All live analysis completed")
 }
 
 // SetIgnoreDirPaths sets paths to ignore

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -266,6 +266,7 @@ func (e *Exporter) RunServer(addr string) {
 	http.Handle("/", http.HandlerFunc(ServeIndex))
 	http.Handle("/metrics", e)
 	http.Handle("/version", http.HandlerFunc(ServeVersion))
+	http.Handle("/health", http.HandlerFunc(ServeHealth))
 
 	// Start background scanning if configured
 	e.StartBackgroundScan()
@@ -275,6 +276,17 @@ func (e *Exporter) RunServer(addr string) {
 	if err != nil {
 		log.Fatal("ListenAndServe:", err)
 	}
+}
+
+// ServeHealth serves health check endpoint
+func ServeHealth(w http.ResponseWriter, req *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	healthInfo := map[string]string{
+		"status": "ok",
+		"version": build.BuildVersion,
+	}
+	json.NewEncoder(w).Encode(healthInfo)
 }
 
 // ServeVersion serves version information
@@ -308,6 +320,9 @@ func ServeIndex(w http.ResponseWriter, req *http.Request) {
 </p>
 <p>
 	<a href="/version">Version</a>
+</p>
+<p>
+	<a href="/health">Health</a>
 </p>
 <p>
 	<a href="https://github.com/dundee/disk_usage_exporter">Homepage</a>

--- a/exporter/exporter.go
+++ b/exporter/exporter.go
@@ -219,7 +219,7 @@ func (e *Exporter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	}
 
 	// Use cached storage data if available, otherwise run analysis
-	if e.storagePath != "" {
+	if e.storagePath != "" && e.scanInterval > 0 {
 		e.loadFromStorage()
 	} else {
 		e.runAnalysis()


### PR DESCRIPTION
  🚀 새로운 기능

  node_disk_usage_bytes 메트릭에 level 라벨 추가
  - 기능: node_disk_usage_bytes 메트릭에 level 라벨을 추가하여 폴더 계층 정보 제공
  - 목적: Grafana 차트에서 루트 폴더와 하위 폴더를 구분하여 표시할 수 있도록 개선
  - 사용 예시:
  node_disk_usage_bytes{level="0",path="/mnt"} 1.5e+12          # 루트 폴더
  node_disk_usage_bytes{level="1",path="/mnt/data"} 8.5e+11    # 하위 폴더
  node_disk_usage_bytes{level="2",path="/mnt/data/logs"} 2.3e+09 # 2레벨 하위 폴더

  📋 기술적 세부사항

  수정된 메트릭 구조:
  - 이전: node_disk_usage_bytes{path="/mnt"}
  - 변경후: node_disk_usage_bytes{level="0",path="/mnt"}

  주요 변경사항:
  1. 메트릭 정의 수정: diskUsage GaugeVec에 level 라벨 추가
  2. 모든 메트릭 호출 업데이트: 4개 위치에서 level 파라미터 추가
    - 라이브 분석 에러 처리 시: level="0"
    - 캐시 데이터 없을 때: level="0"
    - 특정 경로 캐시 누락 시: level="0"
    - 실제 메트릭 보고 시: 동적 level 값 (level="0", level="1", level="2" 등)

  Level 값 의미:
  - Level 0: 분석 대상 루트 폴더 (예: /mnt, /home, /var)
  - Level 1: 루트 폴더 바로 아래 하위 폴더 (예: /mnt/data, /home/user)
  - Level 2+: 더 깊은 하위 폴더들 (설정된 dir-level에 따라)

  🎯 활용 방안

  Grafana 차트 필터링:
  - 루트 폴더 제외: level!="0" 필터 사용
  - 특정 레벨만 표시: level="1" 필터 사용
  - 하위 폴더들만 표시: level=~"[1-9]+" 정규식 사용

  PromQL 쿼리 예시:
  # 루트 폴더 제외하고 하위 폴더들만 표시
  node_disk_usage_bytes{level!="0"}

  # Level 1 폴더들만 표시 (바로 아래 하위 폴더)
  node_disk_usage_bytes{level="1"}

  # 특정 경로의 모든 레벨 합계
  sum(node_disk_usage_bytes{path=~"/mnt/.*"}) by (level)

  🔧 호환성

  기존 기능 유지:
  - node_disk_usage_level_1_bytes 메트릭은 변경 없음
  - 기존 PromQL 쿼리는 level 라벨을 무시하고 계속 동작
  - 하위 호환성 완전 보장

  업그레이드 시 주의사항:
  - 기존 Grafana 대시보드는 수정 없이 계속 동작
  - 새로운 level 라벨 활용 시에만 쿼리 수정 필요

  📊 사용 사례

  대용량 스토리지 모니터링:
  - 루트 마운트 포인트(/mnt)는 차트에서 제외
  - 실제 데이터 폴더들(/mnt/data1, /mnt/data2)만 시각화
  - 저장공간 사용량 트렌드 분석 시 더 정확한 정보 제공

  다계층 폴더 구조 분석:
  - 각 레벨별 디스크 사용량 분석
  - 특정 깊이의 폴더들만 선별적 모니터링
  - 폴더 계층별 용량 관리 정책 수립 지원